### PR TITLE
[Fix] 사기분석 API 응답 keywords 필드 빈 리스트 허용

### DIFF
--- a/app/models/fraud_response.py
+++ b/app/models/fraud_response.py
@@ -3,6 +3,6 @@ from typing import List
 
 class FraudResponse(BaseModel):
     estimatedFraudType: str                  # 분류된 사기 유형
-    keywords: List[str] = Field(..., min_items=1, max_items=3, description="주요 위험 키워드 (최대 3개)")
+    keywords: List[str] = Field(default_factory=list, max_items=3, description="주요 위험 키워드 (최대 3개)")
     explanation: str                      # 해당 유형으로 판단한 이유
-    score: float = Field(..., ge=0, le=80, description="위험도(0~80)")
+    score: float = Field(..., ge=0, le=70, description="위험도(0~70)")


### PR DESCRIPTION
## 💻 Related Issue
- closed #14 
<br/>

## 🚀 Work Description
- FraudResponse 제약 조건중에 keywords 리스트가 크기 1 이상이어야 하는 조건 삭제했습니다
<br/>

## 🙇🏻‍♀️ To Reviewer
- GPT가 안전으로 판단한 경우 사기 유형 None으로 반환하고, keywords를 빈 리스트로 반환하는 경우가 있어 제약조건을 삭제했습니다.
<br/>

## ➕ Next
- Spring 서버 사기유형 None 처리
<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터
  - 검증 규칙 조정: 위험 키워드 입력이 선택 사항이 되어 비어 있는 목록도 허용되며, 최대 3개 제한은 유지됩니다. 이로써 폼/요청에서 키워드를 생략해도 응답이 제공됩니다.
  - 점수 범위 조정: 위험도 점수 상한이 80에서 70으로 낮아져 이제 0~70 범위로 표시·검증됩니다. 기존에 71~80 점수를 기대하던 흐름은 더 이상 유효하지 않으니 임계값·필터 설정을 확인하세요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->